### PR TITLE
fix for accounts >10k followers

### DIFF
--- a/app/modules/FollowerModule.php
+++ b/app/modules/FollowerModule.php
@@ -39,7 +39,7 @@ class FollowerModule {
 
         foreach ($followers as $followers_subarr) {
             foreach ($followers_subarr as $key => $value) {
-                $followers_all[$key] = $value;
+                $followers_all[] = $value;
             }
         }
 
@@ -53,7 +53,7 @@ class FollowerModule {
                 
                 $found = false;
 
-                array_walk($followers, function($value2, $key2) use ($username, &$found) {
+                array_walk($followers, function($value2) use ($username, &$found) {
                     if (isset($value2['string_list_data'][0]['value'])) {
                         if ($username === $value2['string_list_data'][0]['value']) {
                             $found = true;


### PR DESCRIPTION
hey! currently the site overrides the followers_all with only the last page's results (with followers_1 to followers_6, followers_all holds only followers_6), so it pops up a bunch of false positives. not sure how you want to write the change, but this works locally!

thanks so much for making this, by the way! really helpful :D